### PR TITLE
Don't rely on %name for build

### DIFF
--- a/cloud-provider-openstack.spec
+++ b/cloud-provider-openstack.spec
@@ -93,7 +93,7 @@ Provisions volumes using OpenStack Manila API.
 %build
 export GOPATH=$(pwd):$(pwd)/vendor:%{gopath}
 mkdir -p src/%{provider}.%{provider_tld}
-ln -s ../../../%{name} src/%{provider}.%{provider_tld}/
+ln -s ../../../$(basename $(pwd)) src/%{provider}.%{provider_tld}/
 cd src/%{provider}.%{provider_tld}/%{name}
 %gobuild -o manila-provisioner cmd/manila-provisioner/main.go
 


### PR DESCRIPTION
Don't use %name for creating the build directory structure.