### PR TITLE
UPSTREAM: 370: Manila: Add StorageClass parameter to specify NFS share client

### DIFF
--- a/docs/using-manila-provisioner.md
+++ b/docs/using-manila-provisioner.md
@@ -39,6 +39,7 @@ None.
 Key | For backend | For protocol  | Required | Default Value | Description
 --- | ----------- | ------------- | ------------- | ----------- |---------
 `csi-driver` | `csi-cephfs` | `CEPHFS` | Yes | None | Name of the CSI driver
+`nfs-share-client` | `nfs` | `NFS` | No | `0.0.0.0` | Default NFS client for the share
 
 ## Authentication with Manila v2 client
 The provisioner authenticates to the OpenStack Manila service with the credentials supplied from the Kubernetes Secret object referenced by `osSecretNamespace` : `osSecretName`. One can authenticate either as a user or as a trustee, with each of those having its own set of parameters. Note that if the Secret object is created from a manifest, the Secret's values need to be encoded in base64.

--- a/pkg/share/manila/sharebackends/nfs.go
+++ b/pkg/share/manila/sharebackends/nfs.go
@@ -45,11 +45,11 @@ func (NFS) BuildSource(args *BuildSourceArgs) (*v1.PersistentVolumeSource, error
 	}, nil
 }
 
-// GrantAccess to NFS share. Allows read-write access to everyone!
+// GrantAccess to NFS share. Allows read-write access to everyone by default!
 func (NFS) GrantAccess(args *GrantAccessArgs) (*shares.AccessRight, error) {
 	return shares.GrantAccess(args.Client, args.Share.ID, shares.GrantAccessOpts{
 		AccessType:  "ip",
-		AccessTo:    "0.0.0.0/0",
+		AccessTo:    args.Options.BackendOptions.NFSShareClient,
 		AccessLevel: "rw",
 	}).Extract()
 }

--- a/pkg/share/manila/shareoptions/backend.go
+++ b/pkg/share/manila/shareoptions/backend.go
@@ -19,6 +19,6 @@ package shareoptions
 // BackendOptions contains backend-specific options
 type BackendOptions struct {
 	CSICEPHFSdriver string `name:"csi-driver" backend:"csi-cephfs" protocol:"CEPHFS"`
-
+	NFSShareClient  string `name:"nfs-share-client" backend:"nfs" protocol:"NFS" value:"default=0.0.0.0"`
 	// Add more backend options here
 }


### PR DESCRIPTION
This is required for both the kNFS and Ganesha NFS to work -- there is no way to specify a common working default NFS client. Also the default value changes in favour of Ganesha since it's the preferred NFS implementation for OpenShift on OpenStack.