### PR TITLE
Updating csi-driver-manila builder & base images to be consistent with ART

### DIFF
--- a/images/manila-csi-plugin/Dockerfile
+++ b/images/manila-csi-plugin/Dockerfile
@@ -1,9 +1,9 @@
-FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.6
+FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.7
 COPY . /go/src/k8s.io/cloud-provider-openstack
 RUN cd /go/src/k8s.io/cloud-provider-openstack && \
     go build -o manila-csi-plugin cmd/manila-csi-plugin/main.go
 
-FROM registry.svc.ci.openshift.org/ocp/4.6:base
+FROM registry.svc.ci.openshift.org/ocp/4.7:base
 
 COPY --from=0 /go/src/k8s.io/cloud-provider-openstack/manila-csi-plugin /usr/bin/
 


### PR DESCRIPTION
Updating csi-driver-manila builder & base images to be consistent with ART
Reconciling with https://github.com/openshift/ocp-build-data/tree/f66c03011773dc3755ad874fc691be612914d65f/images/csi-driver-manila.yml

If you have any questions about this pull request, please reach out to `@art-team` in the `#aos-art` coreos slack channel.

Depends on https://github.com/openshift/images/pull/44 . Allow it to merge and then run `/test all` on this PR.