### PR TITLE
Bug 1933659: Add udev to the driver image

### DIFF
--- a/images/cinder-csi-plugin/Dockerfile
+++ b/images/cinder-csi-plugin/Dockerfile
@@ -7,7 +7,7 @@ FROM registry.ci.openshift.org/ocp/4.7:base
 
 # Get mkfs & blkid
 RUN yum update -y && \
-    yum install --setopt=tsflags=nodocs -y e2fsprogs xfsprogs util-linux && \
+    yum install --setopt=tsflags=nodocs -y e2fsprogs xfsprogs util-linux systemd-udev && \
     yum clean all && rm -rf /var/cache/yum/*
 
 COPY --from=0 /go/src/k8s.io/cloud-provider-openstack/cinder-csi-plugin /usr/bin/

--- a/images/cinder-csi-plugin/Dockerfile.openshift.ci
+++ b/images/cinder-csi-plugin/Dockerfile.openshift.ci
@@ -7,7 +7,7 @@ FROM registry.svc.ci.openshift.org/openshift/4.6:base
 
 # Get mkfs & blkid
 RUN yum update -y && \
-    yum install --setopt=tsflags=nodocs -y e2fsprogs xfsprogs util-linux && \
+    yum install --setopt=tsflags=nodocs -y e2fsprogs xfsprogs util-linux systemd-udev && \
     yum clean all && rm -rf /var/cache/yum/*
 
 COPY --from=0 /go/src/k8s.io/cloud-provider-openstack/cinder-csi-plugin /usr/bin/


### PR DESCRIPTION
NodeStage / NodePublish need to call "udevadm trigger".

This is manual cherry-pick of #45