### PR TITLE
Bug 1919291: UPSTREAM: 1434: [cinder-csi-plugin] Fix filesystem resize

### DIFF
--- a/pkg/csi/cinder/nodeserver.go
+++ b/pkg/csi/cinder/nodeserver.go
@@ -516,7 +516,7 @@ func (ns *nodeServer) NodeExpandVolume(ctx context.Context, req *csi.NodeExpandV
 	}
 	volumePath := req.GetVolumePath()
 
-	args := []string{"-o", "source", "--noheadings", "--target", volumePath}
+	args := []string{"-o", "source", "--first-only", "--noheadings", "--target", volumePath}
 	output, err := ns.Mount.Mounter().Exec.Command("findmnt", args...).CombinedOutput()
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "Could not determine device path: %v", err)


### PR DESCRIPTION
Now we use "findmnt" command to find the device path. Unfortunately, this command may return multiple entries of the same mount, but in fact we need just the first one.

To prevent this issue we add "--first-only" flag to the command.