### PR TITLE
Fix ART build

### DIFF
--- a/images/cloud-controller-manager/Dockerfile
+++ b/images/cloud-controller-manager/Dockerfile
@@ -1,6 +1,6 @@
 FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.6
 WORKDIR /go/src/k8s.io/cloud-provider-openstack
-COPY ./ ./
+COPY . .
 RUN go build -o openstack-cloud-controller-manager ./cmd/openstack-cloud-controller-manager
 
 FROM registry.svc.ci.openshift.org/ocp/4.6:base


### PR DESCRIPTION
Affected image: openstack-cloud-controller-manager (occm)

**What this PR does / why we need it**:
imagebuilder used by OSBS/brew to create the product images does not
handle slashes in `COPY` commands well. See e.g.
https://github.com/openshift/imagebuilder/issues/139. This commit
ensures the tree is actually present in the container.

**Special notes for reviewers**:
Brew build with unchanged `COPY` command: https://brewweb.engineering.redhat.com/brew/taskinfo?taskID=37981954 
Brew build with `COPY . .`: https://brewweb.engineering.redhat.com/brew/taskinfo?taskID=37983818

```release-note
NONE
```