### PR TITLE
Bug 1996783: Bump Go to v1.16 - fixup

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: golang-1.13
+  tag: golang-1.16


### PR DESCRIPTION
The file named `.ci-operator.yaml` governs which image is used in the
OpenShift CI. This has to be updated as well.