### PR TITLE
Merge upstream

### DIFF
--- a/pkg/csi/cinder/controllerserver.go
+++ b/pkg/csi/cinder/controllerserver.go
@@ -365,7 +365,10 @@ func (cs *controllerServer) CreateSnapshot(ctx context.Context, req *csi.CreateS
 		properties := map[string]string{cinderCSIClusterIDKey: cs.Driver.cluster}
 
 		// see https://github.com/kubernetes-csi/external-snapshotter/pull/375/
-		for _, mKey := range []string{"csi.storage.k8s.io/volumesnapshot/name", "csi.storage.k8s.io/volumesnapshot/namespace", "csi.storage.k8s.io/volumesnapshotcontent/name"} {
+		// Also, we don't want to tag every param but we still want to send the
+		// 'force-create' flag to openstack layer so that we will honor the
+		// force create functions
+		for _, mKey := range []string{"csi.storage.k8s.io/volumesnapshot/name", "csi.storage.k8s.io/volumesnapshot/namespace", "csi.storage.k8s.io/volumesnapshotcontent/name", openstack.SnapshotForceCreate} {
 			if v, ok := req.Parameters[mKey]; ok {
 				properties[mKey] = v
 			}

--- a/pkg/csi/cinder/controllerserver_test.go
+++ b/pkg/csi/cinder/controllerserver_test.go
@@ -494,6 +494,7 @@ func TestCreateSnapshotWithExtraMetadata(t *testing.T) {
 		"csi.storage.k8s.io/volumesnapshot/name":        FakeSnapshotName,
 		"csi.storage.k8s.io/volumesnapshotcontent/name": FakeSnapshotContentName,
 		"csi.storage.k8s.io/volumesnapshot/namespace":   FakeSnapshotNamespace,
+		openstack.SnapshotForceCreate:                   "true",
 	}
 
 	osmock.On("CreateSnapshot", FakeSnapshotName, FakeVolID, &properties).Return(&FakeSnapshotRes, nil)
@@ -511,6 +512,7 @@ func TestCreateSnapshotWithExtraMetadata(t *testing.T) {
 			"csi.storage.k8s.io/volumesnapshot/name":        FakeSnapshotName,
 			"csi.storage.k8s.io/volumesnapshotcontent/name": FakeSnapshotContentName,
 			"csi.storage.k8s.io/volumesnapshot/namespace":   FakeSnapshotNamespace,
+			openstack.SnapshotForceCreate:                   "true",
 		},
 	}
 

--- a/pkg/csi/cinder/openstack/openstack_snapshots.go
+++ b/pkg/csi/cinder/openstack/openstack_snapshots.go
@@ -37,7 +37,7 @@ const (
 	snapReadySteps      = 10
 
 	snapshotDescription = "Created by OpenStack Cinder CSI driver"
-	snapshotForceCreate = "force-create"
+	SnapshotForceCreate = "force-create"
 )
 
 // CreateSnapshot issues a request to take a Snapshot of the specified Volume with the corresponding ID and
@@ -47,14 +47,14 @@ func (os *OpenStack) CreateSnapshot(name, volID string, tags *map[string]string)
 	force := false
 	// if no flag given, then force will be false by default
 	// if flag it given , check it
-	if item, ok := (*tags)[snapshotForceCreate]; ok {
+	if item, ok := (*tags)[SnapshotForceCreate]; ok {
 		var err error
 		force, err = strconv.ParseBool(item)
 		if err != nil {
 			klog.V(5).Infof("Make force create flag to false due to: %v", err)
 		}
 
-		delete(*tags, snapshotForceCreate)
+		delete(*tags, SnapshotForceCreate)
 	}
 	// Force the creation of snapshot even the Volume is in in-use state
 	opts := &snapshots.CreateOpts{

--- a/tests/e2e/csi/cinder/cinder-testdriver.go
+++ b/tests/e2e/csi/cinder/cinder-testdriver.go
@@ -55,9 +55,7 @@ func initCinderDriver(name string, manifests ...string) storageframework.TestDri
 				storageframework.CapTopology:            true,
 				storageframework.CapControllerExpansion: true,
 				storageframework.CapNodeExpansion:       true,
-				storageframework.CapOnlineExpansion:     true,
-				//storageframework.CapSnapshotDataSource: true,
-
+				storageframework.CapSnapshotDataSource:  true,
 			},
 		},
 		manifests: manifests,

--- a/tests/e2e/csi/cinder/csi-volumes.go
+++ b/tests/e2e/csi/cinder/csi-volumes.go
@@ -19,7 +19,7 @@ var CSITestSuites = []func() storageframework.TestSuite{
 	testsuites.InitVolumeModeTestSuite,
 	testsuites.InitEphemeralTestSuite,
 	//testsuites.InitVolumeIOTestSuite,
-	//testsuites.InitSnapshottableTestSuite,
+	testsuites.InitSnapshottableTestSuite,
 	testsuites.InitMultiVolumeTestSuite,
 	testsuites.InitFsGroupChangePolicyTestSuite,
 	testsuites.InitTopologyTestSuite,

--- a/tests/playbooks/roles/install-csi-cinder/tasks/main.yaml
+++ b/tests/playbooks/roles/install-csi-cinder/tasks/main.yaml
@@ -71,6 +71,14 @@
       kubectl apply -f manifests/cinder-csi-plugin
   ignore_errors: true
 
+- name: Deploy snapshot manifests
+  shell:
+    executable: /bin/bash
+    cmd: |
+      kubectl apply -k 'github.com/kubernetes-csi/external-snapshotter/client/config/crd?ref=release-5.0'
+      kubectl apply -k 'github.com/kubernetes-csi/external-snapshotter/deploy/kubernetes/snapshot-controller?ref=release-5.0'
+  ignore_errors: yes
+
 - name: Wait for csi-cinder-controllerplugin up and running
   shell:
     executable: /bin/bash
@@ -93,8 +101,19 @@
   delay: 5
   ignore_errors: true
 
+- name: Wait for snapshot-controller deployment up and running
+  shell:
+    executable: /bin/bash
+    cmd: |
+      kubectl -n kube-system get pod | grep snapshot-controller  | grep Running
+  register: check_csi_snapshot
+  until: check_csi_snapshot.rc == 0
+  retries: 24
+  delay: 5
+  ignore_errors: yes
+
 - name: Gather additional evidence if csi-cinder-plugin failed to come up
-  when: check_csi_controller.failed or check_csi_node.failed
+  when: check_csi_controller.failed or check_csi_node.failed or check_csi_snapshot.failed
   block:
     - name: Describe failed csi-cinder-plugin
       shell:
@@ -103,6 +122,7 @@
           kubectl get pods -A
           kubectl -n kube-system describe deployment csi-cinder-controllerplugin
           kubectl -n kube-system describe daemonset csi-cinder-nodeplugin
+          kubectl -n kube-system describe deployment snapshot-controller
       register: describe_csi
       changed_when: false
 


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
