### PR TITLE
openshift: Bump base images to 4.12, Go 1.18

### DIFF
--- a/images/cinder-csi-plugin/Dockerfile
+++ b/images/cinder-csi-plugin/Dockerfile
@@ -1,9 +1,9 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.17-openshift-4.11
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.18-openshift-4.12
 WORKDIR /go/src/k8s.io/cloud-provider-openstack
 COPY . .
 RUN go build -o cinder-csi-plugin ./cmd/cinder-csi-plugin
 
-FROM registry.ci.openshift.org/ocp/4.11:base
+FROM registry.ci.openshift.org/ocp/4.12:base
 
 # Get mkfs & blkid
 RUN yum update -y && \

--- a/images/cloud-controller-manager/Dockerfile
+++ b/images/cloud-controller-manager/Dockerfile
@@ -1,9 +1,9 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.17-openshift-4.11
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.18-openshift-4.12
 WORKDIR /go/src/k8s.io/cloud-provider-openstack
 COPY . .
 RUN go build -o openstack-cloud-controller-manager ./cmd/openstack-cloud-controller-manager
 
-FROM registry.ci.openshift.org/ocp/4.11:base
+FROM registry.ci.openshift.org/ocp/4.12:base
 
 COPY --from=0 /go/src/k8s.io/cloud-provider-openstack/openstack-cloud-controller-manager /usr/bin/
 

--- a/images/manila-csi-plugin/Dockerfile
+++ b/images/manila-csi-plugin/Dockerfile
@@ -1,9 +1,9 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.17-openshift-4.11
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.18-openshift-4.12
 WORKDIR /go/src/k8s.io/cloud-provider-openstack
 COPY . .
 RUN go build -o manila-csi-plugin ./cmd/manila-csi-plugin
 
-FROM registry.ci.openshift.org/ocp/4.11:base
+FROM registry.ci.openshift.org/ocp/4.12:base
 
 COPY --from=0 /go/src/k8s.io/cloud-provider-openstack/manila-csi-plugin /usr/bin/
 


### PR DESCRIPTION
Upgrade base images to be consistent with `go.mod` and OpenShift 4.12.