### PR TITLE
go.mod: Revert to Go v1.17

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module k8s.io/cloud-provider-openstack
 
-go 1.18
+go 1.17
 
 require (
 	github.com/container-storage-interface/spec v1.5.0


### PR DESCRIPTION
OpenShift 4.11 is compiled on Go v1.17. A partial revert of https://github.com/openshift/cloud-provider-openstack/pull/114