### PR TITLE
Bug OCPBUGS-859: Do not create HTTP monitors for UDP on old Octavia

### DIFF
--- a/pkg/util/openstack/loadbalancer.go
+++ b/pkg/util/openstack/loadbalancer.go
@@ -42,6 +42,7 @@ const (
 	OctaviaFeatureFlavors           = 2
 	OctaviaFeatureTimeout           = 3
 	OctaviaFeatureAvailabilityZones = 4
+	OctaviaFeatureHTTPMonitorsOnUDP = 5
 
 	waitLoadbalancerInitDelay   = 1 * time.Second
 	waitLoadbalancerFactor      = 1.2
@@ -141,6 +142,14 @@ func IsOctaviaFeatureSupported(client *gophercloud.ServiceClient, feature int, l
 		}
 		verAvailabilityZones, _ := version.NewVersion("v2.14")
 		if currentVer.GreaterThanOrEqual(verAvailabilityZones) {
+			return true
+		}
+	case OctaviaFeatureHTTPMonitorsOnUDP:
+		if lbProvider == "ovn" {
+			return false
+		}
+		verHTTPMonitorsOnUDP, _ := version.NewVersion("v2.16")
+		if currentVer.GreaterThanOrEqual(verHTTPMonitorsOnUDP) {
 			return true
 		}
 	default:


### PR DESCRIPTION
Octavia API before 2.16 doesn't support HTTP monitors on UDP pools. It
will however allow creation of such if all-in-one LB creation call is
used. This is a problem for UDP `ETP=Local` Services, where
`healthCheckNodePort` is allocated and CCM will try to create HTTP
monitor there. This monitor will be completely not functional.

OVN Octavia provider doesn't support HTTP health monitors either.

This commit fixes that by making sure we're checking Octavia API version
and if it's lower than 2.16 we fall back to creating UDP-CONNECT health
monitors on a regular port instead. Moreover same is done when provider
is set to "ovn".