### PR TITLE
Bug OCPBUGS-1646: Make sure LB status is updated immediately

### DIFF
--- a/pkg/openstack/loadbalancer.go
+++ b/pkg/openstack/loadbalancer.go
@@ -549,7 +549,7 @@ func (lbaas *LbaasV2) createFullyPopulatedOctaviaLoadBalancer(name, clusterName 
 		svcConf.lbMemberSubnetID = loadbalancer.VipSubnetID
 	}
 
-	if err := openstackutil.WaitLoadbalancerActive(lbaas.lb, loadbalancer.ID); err != nil {
+	if loadbalancer, err = openstackutil.WaitLoadbalancerActive(lbaas.lb, loadbalancer.ID); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
`createFullyPopulatedOctaviaLoadBalancer()` ends with a call to
`WaitLoadbalancerActive()`. It'll only exit without error if that
function succeeded. But later on `ensureOctaviaLoadBalancer()` checks
the LB's `ProvisioningStatus` again and exists if it's not ACTIVE. The
problem is that the comparison is done on LB instance returned from POST
call and not from one of the GET calls done in
`WaitLoadbalancerActive()`, so it's always `PENDING_CREATE`. This means
that for LB to be completely created, `ensureOctaviaLoadBalancer()`
always needs to be called twice, increasing number of Octavia calls
made, time for LBs to be created and user experience by creating false
positive warning Event.

In case multiple LBs are created in a short period - `Service.Status`
of the first one will only be populated once all of them are created as
events are processed in order. This increases the time needed to create
LBs even more.

This commit solves that by making sure `WaitLoadbalancerActive()`
returns last instance of `LoadBalancer` struct it got from Octavia API
and that that object is later used by `ensureLoadBalancer()` logic.