### PR TITLE
OCPBUGS-16783: Chore: Update OWNERS_ALIASES

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -22,6 +22,8 @@ aliases:
   storage-team:
     - bertinatto
     - gnufied
-    - huffmanca
     - jsafrane
     - tsmetana
+    - dobsonj
+    - RomanBednar
+    - mpatlasov


### PR DESCRIPTION
Adding Jonathan and Roman and Maxim in storage maintainers.
