### PR TITLE
CARRY: Add DOWNSTREAM_OWNERS

### DIFF
--- a/DOWNSTREAM_OWNERS
+++ b/DOWNSTREAM_OWNERS
@@ -1,0 +1,10 @@
+# See the CONTRIBUTING docs: https://github.com/openshift/origin/blob/master/CONTRIBUTING.adoc
+
+approvers:
+  - shiftstack-team
+  - cloud-team
+  - storage-team
+reviewers:
+  - shiftstack-team
+component: "Installer"
+subcomponent: "OpenShift on OpenStack"

--- a/DOWNSTREAM_OWNERS_ALIASES
+++ b/DOWNSTREAM_OWNERS_ALIASES
@@ -1,0 +1,29 @@
+# See the OWNERS_ALIASES docs: https://git.k8s.io/community/contributors/guide/owners.md#OWNERS_ALIASES
+
+aliases:
+  shiftstack-team:
+    - EmilienM
+    - MaysaMacedo
+    - dulek
+    - gryf
+    - mandre
+    - mdbooth
+    - pierreprinetti
+    - stephenfin
+
+  cloud-team:
+    - JoelSpeed
+    - RadekManak
+    - damdo
+    - elmiko
+    - odvarkadaniel
+    - nrb
+
+  storage-team:
+    - bertinatto
+    - gnufied
+    - jsafrane
+    - tsmetana
+    - dobsonj
+    - RomanBednar
+    - mpatlasov


### PR DESCRIPTION
This should allow us to remove the carry and avoid merge conflicts on upstream OWNERS.