### PR TITLE
k8s-keystone-auth: Disable HTTP/2 on the auth webhook

### DIFF
--- a/pkg/identity/keystone/config.go
+++ b/pkg/identity/keystone/config.go
@@ -29,6 +29,7 @@ type Config struct {
 	Address             string
 	CertFile            string
 	KeyFile             string
+	EnableHTTP2         bool
 	KeystoneURL         string
 	KeystoneCA          string
 	PolicyFile          string
@@ -84,6 +85,7 @@ func (c *Config) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&c.Address, "listen", c.Address, "<address>:<port> to listen on")
 	fs.StringVar(&c.CertFile, "tls-cert-file", c.CertFile, "File containing the default x509 Certificate for HTTPS.")
 	fs.StringVar(&c.KeyFile, "tls-private-key-file", c.KeyFile, "File containing the default x509 private key matching --tls-cert-file.")
+	fs.BoolVar(&c.EnableHTTP2, "enable-http2", c.EnableHTTP2, "If HTTP/2 should be enabled for the metrics and webhook servers.")
 	fs.StringVar(&c.KeystoneURL, "keystone-url", c.KeystoneURL, "URL for the OpenStack Keystone API")
 	fs.StringVar(&c.KeystoneCA, "keystone-ca-file", c.KeystoneCA, "File containing the certificate authority for Keystone Service.")
 	fs.StringVar(&c.PolicyFile, "keystone-policy-file", c.PolicyFile, "File containing the policy, if provided, it takes precedence over the policy configmap.")

--- a/pkg/identity/keystone/keystone.go
+++ b/pkg/identity/keystone/keystone.go
@@ -120,7 +120,16 @@ func (k *Auth) Run() {
 	r.HandleFunc("/webhook", k.Handler)
 
 	klog.Infof("Starting webhook server...")
-	klog.Fatal(http.ListenAndServeTLS(k.config.Address, k.config.CertFile, k.config.KeyFile, r))
+	tlsConfig := &tls.Config{}
+	if !k.config.EnableHTTP2 {
+		tlsConfig.NextProtos = []string{"http/1.1"}
+	}
+	server := &http.Server{
+		Addr:      k.config.Address,
+		Handler:   r,
+		TLSConfig: tlsConfig,
+	}
+	klog.Fatal(server.ListenAndServeTLS(k.config.CertFile, k.config.KeyFile))
 }
 
 func (k *Auth) enqueueConfigMap(obj interface{}) {


### PR DESCRIPTION
Prevent HTTP/2 abuse.

Is the k8s-keystone-auth tested anywhere? I am not sure that passing an empty tls.Config is like not passing it, and I'd love to have some regression testing to confirm that.

@stephenfin you've committed in this space recently. Do you perhaps know?