### PR TITLE
OCPBUGS-22974: [release-4.14] manage-security-groups: Only add SGs to LB members (#2455)

### DIFF
--- a/pkg/openstack/loadbalancer.go
+++ b/pkg/openstack/loadbalancer.go
@@ -715,20 +715,42 @@ func getSubnetIDForLB(network *gophercloud.ServiceClient, node corev1.Node, pref
 	return "", cpoerrors.ErrNotFound
 }
 
-// applyNodeSecurityGroupIDForLB associates the security group with all the ports on the nodes.
-func applyNodeSecurityGroupIDForLB(network *gophercloud.ServiceClient, nodes []*corev1.Node, sg string) error {
+// isPortMember returns true if IP and subnetID are one of the FixedIPs on the port
+func isPortMember(port PortWithPortSecurity, IP string, subnetID string) bool {
+	for _, fixedIP := range port.FixedIPs {
+		if (subnetID == "" || subnetID == fixedIP.SubnetID) && IP == fixedIP.IPAddress {
+			return true
+		}
+	}
+	return false
+}
+
+// applyNodeSecurityGroupIDForLB associates the security group with the ports being members of the LB on the nodes.
+func applyNodeSecurityGroupIDForLB(network *gophercloud.ServiceClient, svcConf *serviceConfig, nodes []*corev1.Node, sg string) error {
 	for _, node := range nodes {
 		serverID, _, err := instanceIDFromProviderID(node.Spec.ProviderID)
 		if err != nil {
 			return fmt.Errorf("error getting server ID from the node: %w", err)
 		}
+
+		addr, _ := nodeAddressForLB(node, svcConf.preferredIPFamily)
+		if addr == "" {
+			// If node has no viable address let's ignore it.
+			continue
+		}
+
 		listOpts := neutronports.ListOpts{DeviceID: serverID}
-		allPorts, err := openstackutil.GetPorts(network, listOpts)
+		allPorts, err := openstackutil.GetPorts[PortWithPortSecurity](network, listOpts)
 		if err != nil {
 			return err
 		}
 
 		for _, port := range allPorts {
+			// You can't assign an SG to a port with port_security_enabled=false, skip them.
+			if !port.PortSecurityEnabled {
+				continue
+			}
+
 			// If the Security Group is already present on the port, skip it.
 			if slices.Contains(port.SecurityGroups, sg) {
 				continue
@@ -741,6 +763,11 @@ func applyNodeSecurityGroupIDForLB(network *gophercloud.ServiceClient, nodes []*
 			err := neutrontags.Add(network, "ports", port.ID, sg).ExtractErr()
 			if mc.ObserveRequest(err) != nil {
 				return fmt.Errorf("failed to add tag %s to port %s: %v", sg, port.ID, err)
+			}
+
+			// Only add SGs to the port actually attached to the LB
+			if !isPortMember(port, addr, svcConf.lbMemberSubnetID) {
+				continue
 			}
 
 			// Add the SG to the port
@@ -764,7 +791,7 @@ func applyNodeSecurityGroupIDForLB(network *gophercloud.ServiceClient, nodes []*
 func disassociateSecurityGroupForLB(network *gophercloud.ServiceClient, sg string) error {
 	// Find all the ports that have the security group associated.
 	listOpts := neutronports.ListOpts{TagsAny: sg}
-	allPorts, err := openstackutil.GetPorts(network, listOpts)
+	allPorts, err := openstackutil.GetPorts[neutronports.Port](network, listOpts)
 	if err != nil {
 		return err
 	}
@@ -2343,7 +2370,7 @@ func (lbaas *LbaasV2) ensureAndUpdateOctaviaSecurityGroup(clusterName string, ap
 		}
 	}
 
-	if err := applyNodeSecurityGroupIDForLB(lbaas.network, nodes, lbSecGroupID); err != nil {
+	if err := applyNodeSecurityGroupIDForLB(lbaas.network, svcConf, nodes, lbSecGroupID); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/openstack/openstack.go
+++ b/pkg/openstack/openstack.go
@@ -27,6 +27,7 @@ import (
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/availabilityzones"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/servers"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/portsecurity"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/trunk_details"
 	neutronports "github.com/gophercloud/gophercloud/openstack/networking/v2/ports"
 	"github.com/spf13/pflag"
@@ -72,6 +73,11 @@ func AddExtraFlags(fs *pflag.FlagSet) {
 type PortWithTrunkDetails struct {
 	neutronports.Port
 	trunk_details.TrunkDetailsExt
+}
+
+type PortWithPortSecurity struct {
+	neutronports.Port
+	portsecurity.PortSecurityExt
 }
 
 // LoadBalancer is used for creating and maintaining load balancers

--- a/pkg/util/openstack/network.go
+++ b/pkg/util/openstack/network.go
@@ -140,15 +140,16 @@ func getSubnet(networkSubnet string, subnetList []subnets.Subnet) *subnets.Subne
 }
 
 // GetPorts gets all the filtered ports.
-func GetPorts(client *gophercloud.ServiceClient, listOpts neutronports.ListOpts) ([]neutronports.Port, error) {
+func GetPorts[PortType interface{}](client *gophercloud.ServiceClient, listOpts neutronports.ListOpts) ([]PortType, error) {
 	mc := metrics.NewMetricContext("port", "list")
 	allPages, err := neutronports.List(client, listOpts).AllPages()
 	if mc.ObserveRequest(err) != nil {
-		return []neutronports.Port{}, err
+		return []PortType{}, err
 	}
-	allPorts, err := neutronports.ExtractPorts(allPages)
+	var allPorts []PortType
+	err = neutronports.ExtractPortsInto(allPages, &allPorts)
 	if err != nil {
-		return []neutronports.Port{}, err
+		return []PortType{}, err
 	}
 
 	return allPorts, nil

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/portsecurity/doc.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/portsecurity/doc.go
@@ -1,0 +1,145 @@
+/*
+Package portsecurity provides information and interaction with the port
+security extension for the OpenStack Networking service.
+
+Example to List Networks with Port Security Information
+
+	type NetworkWithPortSecurityExt struct {
+		networks.Network
+		portsecurity.PortSecurityExt
+	}
+
+	var allNetworks []NetworkWithPortSecurityExt
+
+	listOpts := networks.ListOpts{
+		Name: "network_1",
+	}
+
+	allPages, err := networks.List(networkClient, listOpts).AllPages()
+	if err != nil {
+		panic(err)
+	}
+
+	err = networks.ExtractNetworksInto(allPages, &allNetworks)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, network := range allNetworks {
+		fmt.Printf("%+v\n", network)
+	}
+
+Example to Create a Network without Port Security
+
+	var networkWithPortSecurityExt struct {
+		networks.Network
+		portsecurity.PortSecurityExt
+	}
+
+	networkCreateOpts := networks.CreateOpts{
+		Name: "private",
+	}
+
+	iFalse := false
+	createOpts := portsecurity.NetworkCreateOptsExt{
+		CreateOptsBuilder:   networkCreateOpts,
+		PortSecurityEnabled: &iFalse,
+	}
+
+	err := networks.Create(networkClient, createOpts).ExtractInto(&networkWithPortSecurityExt)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("%+v\n", networkWithPortSecurityExt)
+
+Example to Disable Port Security on an Existing Network
+
+	var networkWithPortSecurityExt struct {
+		networks.Network
+		portsecurity.PortSecurityExt
+	}
+
+	iFalse := false
+	networkID := "4e8e5957-649f-477b-9e5b-f1f75b21c03c"
+	networkUpdateOpts := networks.UpdateOpts{}
+	updateOpts := portsecurity.NetworkUpdateOptsExt{
+		UpdateOptsBuilder:   networkUpdateOpts,
+		PortSecurityEnabled: &iFalse,
+	}
+
+	err := networks.Update(networkClient, networkID, updateOpts).ExtractInto(&networkWithPortSecurityExt)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("%+v\n", networkWithPortSecurityExt)
+
+Example to Get a Port with Port Security Information
+
+	var portWithPortSecurityExtensions struct {
+		ports.Port
+		portsecurity.PortSecurityExt
+	}
+
+	portID := "46d4bfb9-b26e-41f3-bd2e-e6dcc1ccedb2"
+
+	err := ports.Get(networkingClient, portID).ExtractInto(&portWithPortSecurityExtensions)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("%+v\n", portWithPortSecurityExtensions)
+
+Example to Create a Port Without Port Security
+
+	var portWithPortSecurityExtensions struct {
+		ports.Port
+		portsecurity.PortSecurityExt
+	}
+
+	iFalse := false
+	networkID := "4e8e5957-649f-477b-9e5b-f1f75b21c03c"
+	subnetID := "a87cc70a-3e15-4acf-8205-9b711a3531b7"
+
+	portCreateOpts := ports.CreateOpts{
+		NetworkID: networkID,
+		FixedIPs:  []ports.IP{ports.IP{SubnetID: subnetID}},
+	}
+
+	createOpts := portsecurity.PortCreateOptsExt{
+		CreateOptsBuilder:   portCreateOpts,
+		PortSecurityEnabled: &iFalse,
+	}
+
+	err := ports.Create(networkingClient, createOpts).ExtractInto(&portWithPortSecurityExtensions)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("%+v\n", portWithPortSecurityExtensions)
+
+Example to Disable Port Security on an Existing Port
+
+	var portWithPortSecurityExtensions struct {
+		ports.Port
+		portsecurity.PortSecurityExt
+	}
+
+	iFalse := false
+	portID := "65c0ee9f-d634-4522-8954-51021b570b0d"
+
+	portUpdateOpts := ports.UpdateOpts{}
+	updateOpts := portsecurity.PortUpdateOptsExt{
+		UpdateOptsBuilder:   portUpdateOpts,
+		PortSecurityEnabled: &iFalse,
+	}
+
+	err := ports.Update(networkingClient, portID, updateOpts).ExtractInto(&portWithPortSecurityExtensions)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("%+v\n", portWithPortSecurityExtensions)
+*/
+package portsecurity

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/portsecurity/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/portsecurity/requests.go
@@ -1,0 +1,104 @@
+package portsecurity
+
+import (
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/networks"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/ports"
+)
+
+// PortCreateOptsExt adds port security options to the base ports.CreateOpts.
+type PortCreateOptsExt struct {
+	ports.CreateOptsBuilder
+
+	// PortSecurityEnabled toggles port security on a port.
+	PortSecurityEnabled *bool `json:"port_security_enabled,omitempty"`
+}
+
+// ToPortCreateMap casts a CreateOpts struct to a map.
+func (opts PortCreateOptsExt) ToPortCreateMap() (map[string]interface{}, error) {
+	base, err := opts.CreateOptsBuilder.ToPortCreateMap()
+	if err != nil {
+		return nil, err
+	}
+
+	port := base["port"].(map[string]interface{})
+
+	if opts.PortSecurityEnabled != nil {
+		port["port_security_enabled"] = &opts.PortSecurityEnabled
+	}
+
+	return base, nil
+}
+
+// PortUpdateOptsExt adds port security options to the base ports.UpdateOpts.
+type PortUpdateOptsExt struct {
+	ports.UpdateOptsBuilder
+
+	// PortSecurityEnabled toggles port security on a port.
+	PortSecurityEnabled *bool `json:"port_security_enabled,omitempty"`
+}
+
+// ToPortUpdateMap casts a UpdateOpts struct to a map.
+func (opts PortUpdateOptsExt) ToPortUpdateMap() (map[string]interface{}, error) {
+	base, err := opts.UpdateOptsBuilder.ToPortUpdateMap()
+	if err != nil {
+		return nil, err
+	}
+
+	port := base["port"].(map[string]interface{})
+
+	if opts.PortSecurityEnabled != nil {
+		port["port_security_enabled"] = &opts.PortSecurityEnabled
+	}
+
+	return base, nil
+}
+
+// NetworkCreateOptsExt adds port security options to the base
+// networks.CreateOpts.
+type NetworkCreateOptsExt struct {
+	networks.CreateOptsBuilder
+
+	// PortSecurityEnabled toggles port security on a port.
+	PortSecurityEnabled *bool `json:"port_security_enabled,omitempty"`
+}
+
+// ToNetworkCreateMap casts a CreateOpts struct to a map.
+func (opts NetworkCreateOptsExt) ToNetworkCreateMap() (map[string]interface{}, error) {
+	base, err := opts.CreateOptsBuilder.ToNetworkCreateMap()
+	if err != nil {
+		return nil, err
+	}
+
+	network := base["network"].(map[string]interface{})
+
+	if opts.PortSecurityEnabled != nil {
+		network["port_security_enabled"] = &opts.PortSecurityEnabled
+	}
+
+	return base, nil
+}
+
+// NetworkUpdateOptsExt adds port security options to the base
+// networks.UpdateOpts.
+type NetworkUpdateOptsExt struct {
+	networks.UpdateOptsBuilder
+
+	// PortSecurityEnabled toggles port security on a port.
+	PortSecurityEnabled *bool `json:"port_security_enabled,omitempty"`
+}
+
+// ToNetworkUpdateMap casts a UpdateOpts struct to a map.
+func (opts NetworkUpdateOptsExt) ToNetworkUpdateMap() (map[string]interface{}, error) {
+	base, err := opts.UpdateOptsBuilder.ToNetworkUpdateMap()
+	if err != nil {
+		return nil, err
+	}
+
+	network := base["network"].(map[string]interface{})
+
+	if opts.PortSecurityEnabled != nil {
+		network["port_security_enabled"] = &opts.PortSecurityEnabled
+	}
+
+	return base, nil
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/portsecurity/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/portsecurity/results.go
@@ -1,0 +1,7 @@
+package portsecurity
+
+type PortSecurityExt struct {
+	// PortSecurityEnabled specifies whether port security is enabled or
+	// disabled.
+	PortSecurityEnabled bool `json:"port_security_enabled"`
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -183,6 +183,7 @@ github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/external
 github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/extraroutes
 github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/floatingips
 github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/routers
+github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/portsecurity
 github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/groups
 github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/rules
 github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/trunk_details


### PR DESCRIPTION
Previous code for manage-security-groups were adding the SGs to all the ports attached to the Node. That doesn't make a lot of sense, we only need this traffic opened to the LB members and we only add one port of the Node as the LB member. Moreover we've even tried to add SGs to the ports that had `port_security_enabled=false` which obviously failed.

This patch makes sure that we only add the SG opening NodePort traffic to the port that is actually plugged into the LB. Moreover it adds a check for `port_security_enabled` to make sure that ports with it disabled are ignored.