### PR TITLE
OCPBUGS-56027: [cinder-csi-plugin] Don't report topology capability when --with-topology=False

### DIFF
--- a/pkg/csi/cinder/driver.go
+++ b/pkg/csi/cinder/driver.go
@@ -88,7 +88,7 @@ func NewDriver(o *DriverOpts) *Driver {
 	klog.Info("Driver: ", d.name)
 	klog.Info("Driver version: ", d.fqVersion)
 	klog.Info("CSI Spec version: ", specVersion)
-	klog.Infof("Topology awareness: %T", d.withTopology)
+	klog.Infof("Topology awareness: %t", d.withTopology)
 
 	d.AddControllerServiceCapabilities(
 		[]csi.ControllerServiceCapability_RPC_Type{

--- a/pkg/csi/cinder/identityserver.go
+++ b/pkg/csi/cinder/identityserver.go
@@ -52,36 +52,39 @@ func (ids *identityServer) Probe(ctx context.Context, req *csi.ProbeRequest) (*c
 
 func (ids *identityServer) GetPluginCapabilities(ctx context.Context, req *csi.GetPluginCapabilitiesRequest) (*csi.GetPluginCapabilitiesResponse, error) {
 	klog.V(5).Infof("GetPluginCapabilities called with req %+v", req)
-	return &csi.GetPluginCapabilitiesResponse{
-		Capabilities: []*csi.PluginCapability{
-			{
-				Type: &csi.PluginCapability_Service_{
-					Service: &csi.PluginCapability_Service{
-						Type: csi.PluginCapability_Service_CONTROLLER_SERVICE,
-					},
-				},
-			},
-			{
-				Type: &csi.PluginCapability_Service_{
-					Service: &csi.PluginCapability_Service{
-						Type: csi.PluginCapability_Service_VOLUME_ACCESSIBILITY_CONSTRAINTS,
-					},
-				},
-			},
-			{
-				Type: &csi.PluginCapability_VolumeExpansion_{
-					VolumeExpansion: &csi.PluginCapability_VolumeExpansion{
-						Type: csi.PluginCapability_VolumeExpansion_ONLINE,
-					},
-				},
-			},
-			{
-				Type: &csi.PluginCapability_VolumeExpansion_{
-					VolumeExpansion: &csi.PluginCapability_VolumeExpansion{
-						Type: csi.PluginCapability_VolumeExpansion_OFFLINE,
-					},
+	caps := []*csi.PluginCapability{
+		{
+			Type: &csi.PluginCapability_Service_{
+				Service: &csi.PluginCapability_Service{
+					Type: csi.PluginCapability_Service_CONTROLLER_SERVICE,
 				},
 			},
 		},
-	}, nil
+		{
+			Type: &csi.PluginCapability_VolumeExpansion_{
+				VolumeExpansion: &csi.PluginCapability_VolumeExpansion{
+					Type: csi.PluginCapability_VolumeExpansion_ONLINE,
+				},
+			},
+		},
+		{
+			Type: &csi.PluginCapability_VolumeExpansion_{
+				VolumeExpansion: &csi.PluginCapability_VolumeExpansion{
+					Type: csi.PluginCapability_VolumeExpansion_OFFLINE,
+				},
+			},
+		},
+	}
+
+	if ids.Driver.withTopology {
+		caps = append(caps, &csi.PluginCapability{
+			Type: &csi.PluginCapability_Service_{
+				Service: &csi.PluginCapability_Service{
+					Type: csi.PluginCapability_Service_VOLUME_ACCESSIBILITY_CONSTRAINTS,
+				},
+			},
+		})
+	}
+
+	return &csi.GetPluginCapabilitiesResponse{Capabilities: caps}, nil
 }

--- a/pkg/csi/manila/driver.go
+++ b/pkg/csi/manila/driver.go
@@ -127,6 +127,7 @@ func NewDriver(o *DriverOpts) (*Driver, error) {
 	klog.Info("Driver: ", d.name)
 	klog.Info("Driver version: ", d.fqVersion)
 	klog.Info("CSI spec version: ", specVersion)
+	klog.Infof("Topology awareness: %t", d.withTopology)
 
 	getShareAdapter(d.shareProto) // The program will terminate with a non-zero exit code if the share protocol selector is wrong
 	klog.Infof("Operating on %s shares", d.shareProto)

--- a/pkg/csi/manila/identityserver.go
+++ b/pkg/csi/manila/identityserver.go
@@ -22,6 +22,7 @@ import (
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"k8s.io/klog/v2"
 )
 
 type identityServer struct {
@@ -29,8 +30,14 @@ type identityServer struct {
 }
 
 func (ids *identityServer) GetPluginInfo(ctx context.Context, req *csi.GetPluginInfoRequest) (*csi.GetPluginInfoResponse, error) {
+	klog.V(5).Infof("Using default GetPluginInfo")
+
 	if ids.d.name == "" {
 		return nil, status.Error(codes.Unavailable, "Driver name not configured")
+	}
+
+	if ids.d.fqVersion == "" {
+		return nil, status.Error(codes.Unavailable, "Driver is missing version")
 	}
 
 	return &csi.GetPluginInfoResponse{
@@ -50,6 +57,7 @@ func (ids *identityServer) Probe(ctx context.Context, req *csi.ProbeRequest) (*c
 }
 
 func (ids *identityServer) GetPluginCapabilities(ctx context.Context, req *csi.GetPluginCapabilitiesRequest) (*csi.GetPluginCapabilitiesResponse, error) {
+	klog.V(5).Infof("GetPluginCapabilities called with req %+v", req)
 	caps := []*csi.PluginCapability{
 		{
 			Type: &csi.PluginCapability_Service_{


### PR DESCRIPTION
This is downstream-first backport of [1] (which is a backport of [2]). The upstream CI is currently broken and I want to get this now while I work on that CI.

[1] https://github.com/kubernetes/cloud-provider-openstack/pull/2872
[2] https://github.com/kubernetes/cloud-provider-openstack/pull/2862
