### PR TITLE
[manila-csi-plugin] Allow for DHSS=true in manila E2E testing

### DIFF
--- a/tests/e2e/csi/manila/testdriver.go
+++ b/tests/e2e/csi/manila/testdriver.go
@@ -3,6 +3,7 @@ package test
 import (
 	"context"
 	"fmt"
+	"os"
 
 	"github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
@@ -28,6 +29,12 @@ const (
 	manilaShareAccessType = "ip"
 	manilaShareAccessTo   = "0.0.0.0/0"
 	manilaShareSizeGiB    = 1
+)
+
+// Environment variables for DHSS=True (driver_handles_share_servers) mode.
+// Set MANILA_SHARE_NETWORK_ID to enable testing with share networks.
+var (
+	manilaShareNetworkID = os.Getenv("MANILA_SHARE_NETWORK_ID")
 )
 
 type manilaTestDriver struct {
@@ -127,6 +134,11 @@ func (d *manilaTestDriver) GetDynamicProvisionStorageClass(ctx context.Context, 
 		"csi.storage.k8s.io/node-stage-secret-namespace":        manilaSecretNamespace,
 		"csi.storage.k8s.io/node-publish-secret-name":           manilaSecretName,
 		"csi.storage.k8s.io/node-publish-secret-namespace":      manilaSecretNamespace,
+	}
+
+	// Support for DHSS=True mode: include share network ID if specified
+	if manilaShareNetworkID != "" {
+		parameters["shareNetworkID"] = manilaShareNetworkID
 	}
 
 	sc := storageframework.GetStorageClass(


### PR DESCRIPTION
Add env var for manila e2e testing to allow setting manila share network in DHSS = true envs

<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
