### PR TITLE
OCPBUGS-69813: Updating csi-driver-manila-container image to be consistent with ART for 4.22

### DIFF
--- a/images/manila-csi-plugin/Dockerfile
+++ b/images/manila-csi-plugin/Dockerfile
@@ -1,9 +1,9 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.24-openshift-4.21
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.24-openshift-4.22
 WORKDIR /go/src/k8s.io/cloud-provider-openstack
 COPY . .
 RUN go build -o manila-csi-plugin ./cmd/manila-csi-plugin
 
-FROM registry.ci.openshift.org/ocp/4.21:base-rhel9
+FROM registry.ci.openshift.org/ocp/4.22:base-rhel9
 
 COPY --from=0 /go/src/k8s.io/cloud-provider-openstack/manila-csi-plugin /usr/bin/
 


### PR DESCRIPTION
Manual fixup to #359 to replace the non-existent `-minimal` image. See #359 for more information.
