### PR TITLE
OCPBUGS-79847: Apply code mitigations for CVE-2026-33186

### DIFF
--- a/pkg/csi/cinder/server.go
+++ b/pkg/csi/cinder/server.go
@@ -25,6 +25,10 @@ import (
 	"k8s.io/klog/v2"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"context"
 )
 
 // NonBlockingGRPCServer defines Non blocking GRPC server interfaces
@@ -87,8 +91,16 @@ func (s *nonBlockingGRPCServer) serve(endpoint string, ids csi.IdentityServer, c
 		klog.Fatalf("Failed to listen: %v", err)
 	}
 
+	// Mitigation for CVE-2026-33186 in grpc according to https://github.com/grpc/grpc-go/security/advisories/GHSA-p77j-4mvh-x3m3
+	pathValidationInterceptor := func (ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
+		if info.FullMethod == "" || info.FullMethod[0] != '/' {
+			return nil, status.Errorf(codes.Unimplemented, "malformed method name")
+		}   
+		return handler(ctx, req)
+	}
+
 	opts := []grpc.ServerOption{
-		grpc.UnaryInterceptor(logGRPC),
+		grpc.ChainUnaryInterceptor(pathValidationInterceptor, logGRPC),
 	}
 	server := grpc.NewServer(opts...)
 	s.server = server

--- a/pkg/csi/manila/driver.go
+++ b/pkg/csi/manila/driver.go
@@ -33,6 +33,9 @@ import (
 	"k8s.io/cloud-provider-openstack/pkg/csi/manila/manilaclient"
 	"k8s.io/cloud-provider-openstack/pkg/version"
 	"k8s.io/klog/v2"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 type DriverOpts struct {
@@ -301,7 +304,15 @@ func (s *nonBlockingGRPCServer) serve(endpoint string, ids *identityServer, cs *
 		klog.Fatalf("listen failed for GRPC server: %v", err)
 	}
 
-	server := grpc.NewServer(grpc.UnaryInterceptor(func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+	// Mitigation for CVE-2026-33186 in grpc according to https://github.com/grpc/grpc-go/security/advisories/GHSA-p77j-4mvh-x3m3
+	pathValidationInterceptor := func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
+		if info.FullMethod == "" || info.FullMethod[0] != '/' {
+			return nil, status.Errorf(codes.Unimplemented, "malformed method name")
+		}   
+		return handler(ctx, req)
+	}
+
+	server := grpc.NewServer(grpc.ChainUnaryInterceptor(pathValidationInterceptor, func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
 		callID := atomic.AddUint64(&serverGRPCEndpointCallCounter, 1)
 
 		klog.V(3).Infof("[ID:%d] GRPC call: %s", callID, info.FullMethod)

--- a/pkg/kms/server/server.go
+++ b/pkg/kms/server/server.go
@@ -13,6 +13,9 @@ import (
 	"k8s.io/cloud-provider-openstack/pkg/kms/encryption/aescbc"
 	"k8s.io/klog/v2"
 	pb "k8s.io/kms/apis/v1beta1"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 const (
@@ -73,7 +76,15 @@ func Run(configFilePath string, socketpath string, sigchan <-chan os.Signal) (er
 		return err
 	}
 
-	gServer := grpc.NewServer()
+	// Mitigation for CVE-2026-33186 in grpc according to https://github.com/grpc/grpc-go/security/advisories/GHSA-p77j-4mvh-x3m3
+	pathValidationInterceptor := func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
+		if info.FullMethod == "" || info.FullMethod[0] != '/' {
+			return nil, status.Errorf(codes.Unimplemented, "malformed method name")
+		}   
+		return handler(ctx, req)
+	}
+
+	gServer := grpc.NewServer(grpc.UnaryInterceptor(pathValidationInterceptor))
 	pb.RegisterKeyManagementServiceServer(gServer, s)
 
 	serverCh := make(chan error, 1)


### PR DESCRIPTION
https://redhat.atlassian.net/browse/OCPBUGS-79847

Bump google.golang.org/grpc to v1.67.3-sec.1 using below command:

`go mod edit -replace google.golang.org/grpc=github.com/openshift-sustaining/grpc-go@v1.64.1-sec.1`